### PR TITLE
Exclude Latest Branch from Pull Request Workflows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,7 @@ name: test
 on:
   workflow_dispatch:
   pull_request:
+    branches: ['*', '!latest']
   push:
     branches: [latest, main]
 jobs:


### PR DESCRIPTION
Update the pull request events to trigger the `test.yml` workflow only when the pull request targets branches other than the `latest` branch.