### PR TITLE
Remove Badges from Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 # CTest Action
 
-[![License](https://img.shields.io/github/license/threeal/ctest-action)](./LICENSE)
-[![Test Status](https://img.shields.io/github/actions/workflow/status/threeal/ctest-action/test.yml?label=test&branch=main)](https://github.com/threeal/ctest-action/actions/workflows/test.yml)
-
 Test your [CMake](https://cmake.org/) project with [CTest](https://cmake.org/cmake/help/book/mastering-cmake/chapter/Testing%20With%20CMake%20and%20CTest.html) using [GitHub Actions](https://github.com/features/actions). This action simplifies the workflow for testing a CMake project.
 
 ## Features


### PR DESCRIPTION
This pull request resolves #16 by simply removing badges from the root `README.md` file.