### PR TITLE
Remove `latest` Branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,8 @@ name: test
 on:
   workflow_dispatch:
   pull_request:
-    branches: ['*', '!latest']
   push:
-    branches: [latest, main]
+    branches: [main]
 jobs:
   default-usage:
     runs-on: ${{ matrix.os }}-latest


### PR DESCRIPTION
This pull request resolves #19 by removing the `latest` branch from triggering workflow run.