### PR TITLE
Audit Test Workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,9 +15,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.2
+        with:
+          path: ctest-action
 
       - name: Prepare Sample Project
-        run: mv test/* .
+        run: mv ctest-action/test/* .
 
       - name: Configure and Build Project
         uses: threeal/cmake-action@v1.3.0
@@ -25,6 +27,6 @@ jobs:
           run-build: true
 
       - name: Test Project
-        uses: ./
+        uses: ./ctest-action
         with:
           args: ${{ matrix.os == 'windows' && '-C Debug' || '' }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,29 +1,30 @@
-name: test
+name: Test
 on:
   workflow_dispatch:
   pull_request:
   push:
     branches: [main]
 jobs:
-  default-usage:
+  test-action:
+    name: Test Action
     runs-on: ${{ matrix.os }}-latest
     strategy:
       fail-fast: false
       matrix:
         os: [windows, ubuntu, macos]
     steps:
-      - name: Checkout the repository
+      - name: Checkout
         uses: actions/checkout@v4.1.2
 
-      - name: Move the test project to the working directory
+      - name: Prepare Sample Project
         run: mv test/* .
 
-      - name: Configure and build the project
+      - name: Configure and Build Project
         uses: threeal/cmake-action@v1.3.0
         with:
           run-build: true
 
-      - name: Use the action
+      - name: Test Project
         uses: ./
         with:
           args: ${{ matrix.os == 'windows' && '-C Debug' || '' }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,6 +17,10 @@ jobs:
         uses: actions/checkout@v4.1.2
         with:
           path: ctest-action
+          sparse-checkout: |
+            test
+            action.yaml
+          sparse-checkout-cone-mode: false
 
       - name: Prepare Sample Project
         run: mv ctest-action/test/* .


### PR DESCRIPTION
This pull request resolves #23 by auditing the test workflow as follows:
- Renaming workflows, jobs, and steps to follow the standard used in the [Composite Action Starter](https://github.com/threeal/composite-action-starter).
- Checking out the action to the `ctest-action` directory.
- Checking out the action and test files sparsely.