### PR TITLE
Add `build-config` Action Input

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,4 +33,4 @@ jobs:
       - name: Test Project
         uses: ./ctest-action
         with:
-          args: ${{ matrix.os == 'windows' && '-C Debug' || '' }}
+          build-config: ${{ matrix.os == 'windows' && 'Debug' || '' }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,3 +34,29 @@ jobs:
         uses: ./ctest-action
         with:
           build-config: ${{ matrix.os == 'windows' && 'Debug' || '' }}
+
+  test-action-with-build-config:
+    name: Test Action With Build Config
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.2
+        with:
+          path: ctest-action
+          sparse-checkout: |
+            test
+            action.yaml
+          sparse-checkout-cone-mode: false
+
+      - name: Prepare Sample Project
+        run: mv ctest-action/test/* .
+
+      - name: Configure and Build Project
+        uses: threeal/cmake-action@v1.3.0
+        with:
+          run-build: true
+
+      - name: Test Project
+        uses: ./ctest-action
+        with:
+          build-config: Debug

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,11 +29,10 @@ jobs:
         uses: threeal/cmake-action@v1.3.0
         with:
           run-build: true
+          generator: Ninja
 
       - name: Test Project
         uses: ./ctest-action
-        with:
-          build-config: ${{ matrix.os == 'windows' && 'Debug' || '' }}
 
   test-action-with-build-config:
     name: Test Action With Build Config

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ For more information, refer to [action.yml](./action.yml) and the [GitHub Action
 
 | Name | Value Type | Description |
 | --- | --- | --- |
+| `build-config` | string | Choose the configuration to test. |
 | `args` | Multiple strings | Additional arguments to pass during the CTest run. |
 
 > **Note**: Multiple strings mean that the input can be specified with more than one value. Separate each value with a space or a new line.

--- a/action.yaml
+++ b/action.yaml
@@ -5,6 +5,8 @@ branding:
   icon: terminal
   color: gray-dark
 inputs:
+  build-config:
+    description: Choose the configuration to test
   args:
     description: Additional arguments to pass during the CTest run
 runs:
@@ -12,4 +14,4 @@ runs:
   steps:
     - name: Test the CMake project
       shell: ${{ runner.os == 'Windows' && 'pwsh' || 'bash' }}
-      run: ctest --test-dir build --output-on-failure --no-tests=error ${{ inputs.args }}
+      run: ctest --test-dir build --output-on-failure --no-tests=error ${{ inputs.build-config && '-C' }} ${{ inputs.build-config }} ${{ inputs.args }}


### PR DESCRIPTION
This pull request resolves #4 by introducing the following changes:
- Adding a new `build-config` action input.
- Adding a new `test-action-with-build-config` job for testing the `build-config` action input.
- Modifying the `test-action` job to test the sample project without requiring the build config option.