### PR TITLE
Add `test-dir` Action Input

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,8 +37,39 @@ jobs:
       - name: Test Project
         uses: ./ctest-action
 
+  test-action-with-test-dir:
+    name: Test Action With Test Directory Specified
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Project
+        uses: actions/checkout@v4.1.2
+        with:
+          repository: threeal/cpp-starter
+
+      - name: Checkout Action
+        uses: actions/checkout@v4.1.2
+        with:
+          path: ctest-action
+          sparse-checkout: |
+            test
+            action.yaml
+          sparse-checkout-cone-mode: false
+
+      - name: Configure and Build Project
+        uses: threeal/cmake-action@v1.3.0
+        with:
+          build-dir: output
+          generator: Ninja
+          options: BUILD_TESTING=ON
+          run-build: true
+
+      - name: Test Project
+        uses: ./ctest-action
+        with:
+          test-dir: output
+
   test-action-with-build-config:
-    name: Test Action With Build Config
+    name: Test Action With Build Config Specified
     runs-on: windows-latest
     steps:
       - name: Checkout Project

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ For more information, refer to [action.yml](./action.yml) and the [GitHub Action
 
 | Name | Value Type | Description |
 | --- | --- | --- |
+| `test-dir` | path | Specifies the directory in which to look for tests. It defaults to the `build` directory. |
 | `build-config` | string | Choose the configuration to test. |
 | `args` | Multiple strings | Additional arguments to pass during the CTest run. |
 

--- a/action.yaml
+++ b/action.yaml
@@ -5,6 +5,9 @@ branding:
   icon: terminal
   color: gray-dark
 inputs:
+  test-dir:
+    description: Specifies the directory in which to look for tests
+    default: build
   build-config:
     description: Choose the configuration to test
   args:
@@ -14,4 +17,4 @@ runs:
   steps:
     - name: Test the CMake project
       shell: ${{ runner.os == 'Windows' && 'pwsh' || 'bash' }}
-      run: ctest --test-dir build --output-on-failure --no-tests=error ${{ inputs.build-config && '-C' }} ${{ inputs.build-config }} ${{ inputs.args }}
+      run: ctest --test-dir ${{ inputs.test-dir }} --output-on-failure --no-tests=error ${{ inputs.build-config && '-C' }} ${{ inputs.build-config }} ${{ inputs.args }}


### PR DESCRIPTION
This pull request resolves #3 by introducing the following changes:
- Adding a new `test-dir` action input for specifying the directory in which to look for tests.
- Adding a new `test-action-with-test-dir` job for testing the `test-dir` action input.