### PR TITLE
Add `tests-regex` Action Input

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -59,7 +59,6 @@ jobs:
         uses: threeal/cmake-action@v1.3.0
         with:
           build-dir: output
-          generator: Ninja
           options: BUILD_TESTING=ON
           run-build: true
 
@@ -96,3 +95,35 @@ jobs:
         uses: ./ctest-action
         with:
           build-config: Debug
+
+  test-action-with-test-regex:
+    name: Test Action With Test Regex Specified
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Project
+        uses: actions/checkout@v4.1.2
+        with:
+          repository: threeal/cpp-starter
+
+      - name: Modify Project
+        run: echo 'TEST_CASE("failing test") { CHECK(false); }' >> test/sequence_test.cpp
+
+      - name: Checkout Action
+        uses: actions/checkout@v4.1.2
+        with:
+          path: ctest-action
+          sparse-checkout: |
+            test
+            action.yaml
+          sparse-checkout-cone-mode: false
+
+      - name: Configure and Build Project
+        uses: threeal/cmake-action@v1.3.0
+        with:
+          options: BUILD_TESTING=ON
+          run-build: true
+
+      - name: Test Project
+        uses: ./ctest-action
+        with:
+          tests-regex: test fibonacci sequence

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ For more information, refer to [action.yml](./action.yml) and the [GitHub Action
 | --- | --- | --- |
 | `test-dir` | path | Specifies the directory in which to look for tests. It defaults to the `build` directory. |
 | `build-config` | string | Choose the configuration to test. |
+| `tests-regex` | Regex pattern | Run tests matching regular expression. |
 | `args` | Multiple strings | Additional arguments to pass during the CTest run. |
 
 > **Note**: Multiple strings mean that the input can be specified with more than one value. Separate each value with a space or a new line.

--- a/action.yaml
+++ b/action.yaml
@@ -10,6 +10,8 @@ inputs:
     default: build
   build-config:
     description: Choose the configuration to test
+  tests-regex:
+    description: Run tests matching regular expression
   args:
     description: Additional arguments to pass during the CTest run
 runs:
@@ -17,4 +19,4 @@ runs:
   steps:
     - name: Test the CMake project
       shell: ${{ runner.os == 'Windows' && 'pwsh' || 'bash' }}
-      run: ctest --test-dir ${{ inputs.test-dir }} --output-on-failure --no-tests=error ${{ inputs.build-config && '-C' }} ${{ inputs.build-config }} ${{ inputs.args }}
+      run: ctest --test-dir ${{ inputs.test-dir }} --output-on-failure --no-tests=error ${{ inputs.build-config && '-C' }} ${{ inputs.build-config }} ${{ inputs.tests-regex && '--tests-regex' }} '${{ inputs.tests-regex }}' ${{ inputs.args }}


### PR DESCRIPTION
This pull request resolves #5 by introducing the following changes:
- Adding a new `tests-regex` action input for specifying tests to run that match the given regular expression.
- Adding a new `test-action-with-test-regex` job for testing the `tests-regex` action input.