### PR TITLE
Audit CTest Arguments

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -19,4 +19,4 @@ runs:
   steps:
     - name: Test the CMake project
       shell: ${{ runner.os == 'Windows' && 'pwsh' || 'bash' }}
-      run: ctest --test-dir ${{ inputs.test-dir }} --output-on-failure --no-tests=error ${{ inputs.build-config && '-C' }} ${{ inputs.build-config }} ${{ inputs.tests-regex && '--tests-regex' }} '${{ inputs.tests-regex }}' ${{ inputs.args }}
+      run: ctest --test-dir ${{ inputs.test-dir }} ${{ inputs.build-config && '-C' }} ${{ inputs.build-config }} ${{ inputs.tests-regex && '--tests-regex' }} '${{ inputs.tests-regex }}' --output-on-failure --no-tests=error ${{ inputs.args }}

--- a/action.yaml
+++ b/action.yaml
@@ -19,4 +19,4 @@ runs:
   steps:
     - name: Test the CMake project
       shell: ${{ runner.os == 'Windows' && 'pwsh' || 'bash' }}
-      run: ctest --test-dir ${{ inputs.test-dir }} ${{ inputs.build-config && '-C' }} ${{ inputs.build-config }} ${{ inputs.tests-regex && '--tests-regex' }} '${{ inputs.tests-regex }}' --output-on-failure --no-tests=error ${{ inputs.args }}
+      run: ctest --test-dir '${{ inputs.test-dir }}' ${{ inputs.build-config && '-C' }} '${{ inputs.build-config }}' ${{ inputs.tests-regex && '--tests-regex' }} '${{ inputs.tests-regex }}' --output-on-failure --no-tests=error ${{ inputs.args }}

--- a/action.yaml
+++ b/action.yaml
@@ -19,4 +19,4 @@ runs:
   steps:
     - name: Test the CMake project
       shell: ${{ runner.os == 'Windows' && 'pwsh' || 'bash' }}
-      run: ctest --test-dir '${{ inputs.test-dir }}' ${{ inputs.build-config && '-C' }} '${{ inputs.build-config }}' ${{ inputs.tests-regex && '--tests-regex' }} '${{ inputs.tests-regex }}' --output-on-failure --no-tests=error ${{ inputs.args }}
+      run: ctest --test-dir '${{ inputs.test-dir }}'${{ inputs.build-config && format(' -C ''{0}''', inputs.build-config) }}${{ inputs.tests-regex && format(' --tests-regex ''{0}''', inputs.tests-regex) }} --output-on-failure --no-tests=error ${{ inputs.args }}

--- a/action.yaml
+++ b/action.yaml
@@ -19,4 +19,4 @@ runs:
   steps:
     - name: Test the CMake project
       shell: ${{ runner.os == 'Windows' && 'pwsh' || 'bash' }}
-      run: ctest --test-dir '${{ inputs.test-dir }}'${{ inputs.build-config && format(' -C ''{0}''', inputs.build-config) }}${{ inputs.tests-regex && format(' --tests-regex ''{0}''', inputs.tests-regex) }} --output-on-failure --no-tests=error ${{ inputs.args }}
+      run: ctest --test-dir '${{ inputs.test-dir }}'${{ inputs.build-config && format(' --build-config ''{0}''', inputs.build-config) }}${{ inputs.tests-regex && format(' --tests-regex ''{0}''', inputs.tests-regex) }} --output-on-failure --no-tests=error ${{ inputs.args }}


### PR DESCRIPTION
This pull request resolves #30 by organizing the CTest arguments. It also guards some arguments with quotation marks to handle input with space characters.