### PR TITLE
Add Verbose Input

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -38,6 +38,11 @@ jobs:
       - name: Test Project
         uses: ./ctest-action
 
+      - name: Test Project Verbosely
+        uses: ./ctest-action
+        with:
+          verbose: true
+
   test-action-with-test-dir:
     name: Test Action With Test Directory Specified
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ By default, this action invokes `ctest` with the `--output-on-failure` and `--no
 | `test-dir` | Path | Specifies the directory in which to look for tests. It defaults to the `build` directory. |
 | `build-config` | String | Chooses the configuration to test. |
 | `tests-regex` | Regex pattern | Runs tests matching the regular expression. |
+| `verbose` | Enable verbose output from tests. |
 | `args` | Multiple strings | Additional arguments to pass during the CTest run. |
 
 ## Example Usages

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ jobs:
           run-build: true
 
       - name: Test Project
-        uses: threeal/ctest-action@v1.0.0
+        uses: threeal/ctest-action@v1.1.0
 ```
 
 ### Testing in a Different Directory
@@ -48,7 +48,7 @@ By default, this action runs tests in the `build` directory. To run tests in a d
 
 ```yaml
 - name: Test Project
-  uses: threeal/ctest-action@v1.0.0
+  uses: threeal/ctest-action@v1.1.0
   with:
     test-dir: sample/build
 ```
@@ -59,7 +59,7 @@ Some projects may require a build configuration to be specified to run tests. To
 
 ```yaml
 - name: Test Project
-  uses: threeal/ctest-action@v1.0.0
+  uses: threeal/ctest-action@v1.1.0
   with:
     build-config: Debug
 ```
@@ -70,7 +70,7 @@ A regular expression pattern can be provided by specifying the `tests-regex` inp
 
 ```yaml
 - name: Test Project
-  uses: threeal/ctest-action@v1.0.0
+  uses: threeal/ctest-action@v1.1.0
   with:
     tests-regex: ^test sample
 ```

--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,8 @@ inputs:
     description: Chooses the configuration to test
   tests-regex:
     description: Runs tests matching the regular expression
+  verbose:
+    description: Enable verbose output from tests
   args:
     description: Additional arguments to pass during the CTest run
 runs:
@@ -19,4 +21,4 @@ runs:
   steps:
     - name: Test the CMake project
       shell: ${{ runner.os == 'Windows' && 'pwsh' || 'bash' }}
-      run: ctest --test-dir '${{ inputs.test-dir }}'${{ inputs.build-config && format(' --build-config ''{0}''', inputs.build-config) }}${{ inputs.tests-regex && format(' --tests-regex ''{0}''', inputs.tests-regex) }} --output-on-failure --no-tests=error ${{ inputs.args }}
+      run: ctest --test-dir '${{ inputs.test-dir }}'${{ inputs.build-config && format(' --build-config ''{0}''', inputs.build-config) }}${{ inputs.tests-regex && format(' --tests-regex ''{0}''', inputs.tests-regex) }}${{ inputs.verbose && ' --verbose' }} --output-on-failure --no-tests=error ${{ inputs.args }}


### PR DESCRIPTION
This pull request resolves #42 by adding a `verbose` input to enable verbose output when running tests. This change also bumps the action version to v1.1.0.