### PR TITLE
Specify External Project Version to Use in Workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/checkout@v4.1.6
         with:
           repository: threeal/cpp-starter
+          ref: v1.0.0
 
       - name: Checkout Action
         uses: actions/checkout@v4.1.6
@@ -45,6 +46,7 @@ jobs:
         uses: actions/checkout@v4.1.6
         with:
           repository: threeal/cpp-starter
+          ref: v1.0.0
 
       - name: Checkout Action
         uses: actions/checkout@v4.1.6
@@ -75,6 +77,7 @@ jobs:
         uses: actions/checkout@v4.1.6
         with:
           repository: threeal/cpp-starter
+          ref: v1.0.0
 
       - name: Checkout Action
         uses: actions/checkout@v4.1.6
@@ -104,6 +107,7 @@ jobs:
         uses: actions/checkout@v4.1.6
         with:
           repository: threeal/cpp-starter
+          ref: v1.0.0
 
       - name: Modify Project
         run: echo 'TEST_CASE("failing test") { CHECK(false); }' >> test/sequence_test.cpp


### PR DESCRIPTION
This pull request resolves #44 by specifying the version of the external project to be used in this workflow. This change specifies the [C++ Starter](https://github.com/threeal/cpp-starter/) project to use version [1.0.0](https://github.com/threeal/cpp-starter/releases/tag/v1.0.0).