### PR TITLE
Fix Verbose Input Type Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ By default, this action invokes `ctest` with the `--output-on-failure` and `--no
 | `test-dir` | Path | Specifies the directory in which to look for tests. It defaults to the `build` directory. |
 | `build-config` | String | Chooses the configuration to test. |
 | `tests-regex` | Regex pattern | Runs tests matching the regular expression. |
-| `verbose` | Enable verbose output from tests. |
+| `verbose` | `true` or `false` | Enable verbose output from tests. |
 | `args` | Multiple strings | Additional arguments to pass during the CTest run. |
 
 ## Example Usages


### PR DESCRIPTION
This pull request fixes the missing type information for the `verbose` input in the `README.md` file.