### PR TITLE
Bump Workflows to Use Ubuntu 24.04

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   build-action:
     name: Build Action
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout Project
         uses: actions/checkout@v4.2.2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-14, windows-2022]
+        os: [ubuntu-24.04, macos-14, windows-2022]
     steps:
       - name: Checkout Project
         uses: actions/checkout@v4.2.2

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ on:
 jobs:
   test-project:
     name: Test Project
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.2


### PR DESCRIPTION
This pull request updates workflows in this project to use the [Ubuntu 24.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md) runner.