### PR TITLE
Synchronize Dependency Versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,19 +9,19 @@
     "gha-utils": "^0.4.1"
   },
   "devDependencies": {
-    "@eslint/js": "^9.27.0",
+    "@eslint/js": "^9.28.0",
     "@rollup/plugin-node-resolve": "^16.0.1",
     "@rollup/plugin-typescript": "^12.1.2",
     "@tsconfig/node20": "^20.1.5",
     "@types/node": "^22.15.30",
     "@vitest/coverage-v8": "^3.1.4",
-    "eslint": "^9.27.0",
+    "eslint": "^9.28.0",
     "lefthook": "^1.11.13",
     "prettier": "^3.5.3",
     "rollup": "^4.42.0",
     "tslib": "^2.8.1",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.34.0",
-    "vitest": "^3.0.8"
+    "vitest": "^3.1.4"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ importers:
         version: 0.4.1
     devDependencies:
       '@eslint/js':
-        specifier: ^9.27.0
+        specifier: ^9.28.0
         version: 9.28.0
       '@rollup/plugin-node-resolve':
         specifier: ^16.0.1
@@ -31,7 +31,7 @@ importers:
         specifier: ^3.1.4
         version: 3.1.4(vitest@3.1.4(@types/node@22.15.30))
       eslint:
-        specifier: ^9.27.0
+        specifier: ^9.28.0
         version: 9.28.0
       lefthook:
         specifier: ^1.11.13
@@ -52,7 +52,7 @@ importers:
         specifier: ^8.34.0
         version: 8.34.0(eslint@9.28.0)(typescript@5.8.3)
       vitest:
-        specifier: ^3.0.8
+        specifier: ^3.1.4
         version: 3.1.4(@types/node@22.15.30)
 
 packages:
@@ -660,15 +660,6 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
-
-  debug@4.4.0:
-    resolution: {integrity: sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==}
-    engines: {node: '>=6.0'}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
 
   debug@4.4.1:
     resolution: {integrity: sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==}
@@ -1877,10 +1868,6 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
-  debug@4.4.0:
-    dependencies:
-      ms: 2.1.3
-
   debug@4.4.1:
     dependencies:
       ms: 2.1.3
@@ -2491,7 +2478,7 @@ snapshots:
       '@vitest/spy': 3.1.4
       '@vitest/utils': 3.1.4
       chai: 5.2.0
-      debug: 4.4.0
+      debug: 4.4.1
       expect-type: 1.2.1
       magic-string: 0.30.17
       pathe: 2.0.3


### PR DESCRIPTION
This pull request resolves #275 by synchronizing the dependency versions in the `package.json` and `pnpm-lock.yaml` files.