### PR TITLE
Add Prettier Plugin for Organizing Imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 .*
 !.git*
 !.npmrc
-!.prettierignore
+!.prettier*
 
 node_modules/

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["prettier-plugin-organize-imports"]
+}

--- a/dist/main.bundle.mjs
+++ b/dist/main.bundle.mjs
@@ -35,22 +35,6 @@ function logCommand(command, ...args) {
     process.stdout.write(`[command]${message}${os.EOL}`);
 }
 
-async function executeProcess(command, ...args) {
-    logCommand(command, ...args);
-    const proc = spawn(command, args, { stdio: "inherit" });
-    return new Promise((resolve, reject) => {
-        proc.on("error", reject);
-        proc.on("close", (code) => {
-            if (code === 0) {
-                resolve();
-            }
-            else if (code !== null) {
-                reject(new Error(`Process failed with exit code ${code.toString()}`));
-            }
-        });
-    });
-}
-
 function getCtestArguments() {
     const args = ["--test-dir", getInput("test-dir")];
     const buildConfig = getInput("build-config");
@@ -65,6 +49,22 @@ function getCtestArguments() {
         .split(/\s+/)
         .filter((arg) => arg !== ""));
     return args;
+}
+
+async function executeProcess(command, ...args) {
+    logCommand(command, ...args);
+    const proc = spawn(command, args, { stdio: "inherit" });
+    return new Promise((resolve, reject) => {
+        proc.on("error", reject);
+        proc.on("close", (code) => {
+            if (code === 0) {
+                resolve();
+            }
+            else if (code !== null) {
+                reject(new Error(`Process failed with exit code ${code.toString()}`));
+            }
+        });
+    });
 }
 
 try {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "jiti": "^2.4.2",
     "lefthook": "^1.12.2",
     "prettier": "^3.6.2",
+    "prettier-plugin-organize-imports": "^4.2.0",
     "rollup": "^4.44.1",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.38.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,9 @@ importers:
       prettier:
         specifier: ^3.6.2
         version: 3.6.2
+      prettier-plugin-organize-imports:
+        specifier: ^4.2.0
+        version: 4.2.0(prettier@3.6.2)(typescript@5.8.3)
       rollup:
         specifier: ^4.44.1
         version: 4.44.1
@@ -1107,6 +1110,16 @@ packages:
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
+
+  prettier-plugin-organize-imports@4.2.0:
+    resolution: {integrity: sha512-Zdy27UhlmyvATZi67BTnLcKTo8fm6Oik59Sz6H64PgZJVs6NJpPD1mT240mmJn62c98/QaL+r3kx9Q3gRpDajg==}
+    peerDependencies:
+      prettier: '>=2.0'
+      typescript: '>=2.9'
+      vue-tsc: ^2.1.0 || 3
+    peerDependenciesMeta:
+      vue-tsc:
+        optional: true
 
   prettier@3.6.2:
     resolution: {integrity: sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==}
@@ -2321,6 +2334,11 @@ snapshots:
       source-map-js: 1.2.1
 
   prelude-ls@1.2.1: {}
+
+  prettier-plugin-organize-imports@4.2.0(prettier@3.6.2)(typescript@5.8.3):
+    dependencies:
+      prettier: 3.6.2
+      typescript: 5.8.3
 
   prettier@3.6.2: {}
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import { logError } from "gha-utils";
-import { executeProcess } from "./exec.js";
 import { getCtestArguments } from "./args.js";
+import { executeProcess } from "./exec.js";
 
 try {
   await executeProcess("ctest", ...getCtestArguments());


### PR DESCRIPTION
This pull request resolves #334 by adding [prettier-plugin-organize-imports](https://www.npmjs.com/package/prettier-plugin-organize-imports) to this project. This change also fixes formatting by organizing imports according to the plugin's rules.